### PR TITLE
ci(konflux): add slack notifications on master build failures

### DIFF
--- a/.tekton/registry-proxy-tests-push.yaml
+++ b/.tekton/registry-proxy-tests-push.yaml
@@ -29,6 +29,8 @@ spec:
     value: Dockerfile
   - name: path-context
     value: .
+  - name: slack-notification-on-failure
+    value: "true"
   pipelineRef:
     name: quayio-build-pipeline
   taskRunTemplate:


### PR DESCRIPTION
Adding slack notifications on Konflux build failures on master.