### PR TITLE
fix: update template to match reg proxy main repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,10 @@ LABEL com.redhat.component="registry-proxy-tests" \
       vendor="Red Hat, Inc." \
       name="registry-proxy-tests"
 
+ENV HOME=/home/podman
+RUN mkdir -p /home/podman/.config/containers && \
+    chmod -R 777 /home/podman
+
 # Copy the test script
 COPY test-sigstore.sh /test-sigstore.sh
 RUN chmod +x /test-sigstore.sh

--- a/openshift/acceptance.yaml
+++ b/openshift/acceptance.yaml
@@ -7,7 +7,9 @@ objects:
 - apiVersion: batch/v1
   kind: Job
   metadata:
-    name: registry-proxy-acceptance-job
+    name: ${NAME}
+    annotations:
+      ignore-check.kube-linter.io/unset-cpu-requirements: "CPU limits not set by design"
   spec:
     backoffLimit: 5
     template:
@@ -15,11 +17,14 @@ objects:
         restartPolicy: Never
         containers:
         - name: registry-proxy-test
-          image: ${IMAGE}
+          image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: Always
-          securityContext:
-            runAsUser: 1000
-            runAsGroup: 1000
+          resources:
+            limits:
+              memory: ${TEST_MEMORY_LIMIT}
+            requests:
+              cpu: ${TEST_CPU_REQUEST}
+              memory: ${TEST_MEMORY_REQUEST}
           env:
             - name: HOST
               value: ${HOST}
@@ -34,9 +39,16 @@ objects:
             - name: SIGSTORE_PATH
               value: ${SIGSTORE_PATH}
 parameters:
+  - name: NAME
+    description: name of the job to run
+    value: "registry-proxy-tests"
   - name: IMAGE
     description: container image of acceptance tests
-    value: "quay.io/marckok/registry-proxy-test:latest"
+    value: "quay.io/redhat-services-prod/quayio-tenant/registry-proxy-tests"
+  - name: IMAGE_TAG
+    displayName: acceptance test image version
+    description: acceptance test image version which defaults to latest
+    value: "latest"
   - name: HOST
     description: host to run acceptance test against
     value: "registry.stage.redhat.io"
@@ -55,3 +67,12 @@ parameters:
   - name: SIGSTORE_PATH
     description: path for sigstore validation request
     value: "redhat/community-operator-index@sha256=637bf3e5b650053af96f32a4e43f9f2636c13c36c63538c330164cec6aacfd7a/signature-1"
+  - name: TEST_MEMORY_LIMIT
+    description: Memory limit for the test container
+    value: "640Mi"
+  - name: TEST_MEMORY_REQUEST
+    description: Memory request for the test container
+    value: "128Mi"
+  - name: TEST_CPU_REQUEST
+    description: CPU request for the test container
+    value: "100m"


### PR DESCRIPTION
- Update this template to match with the main one, https://github.com/quay/registry-proxy/blob/main/deploy/openshift/acceptance.yaml
- Add a fix for this test failure:
```
Starting image pull test
Pulling image:
stat /.config: no such file or directory
Logging into registry
stat /.config: no such file or directory
stat /.config: no such file or directory
Image pull failed
```

I will remove the acceptance template from the main repo as it doesn't make sense in there