### PR TITLE
PROJQUAY-11621: docs: add repo context files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# Agent Guide: registry-proxy-tests
+
+## Purpose
+
+Containerized acceptance tests for `quay/registry-proxy`.
+
+## Start Here
+
+- Entrypoint: `execute.sh`
+- Pull test: `test-pull.sh`
+- Sigstore redirect test: `test-sigstore.sh`
+- OpenShift job: `openshift/acceptance.yaml`
+- Konflux pipelines: `.tekton/`
+
+## Common Tasks
+
+- Add test: create a script, call it from `execute.sh`, document new env vars.
+- Debug failure: check `HOST`, image/tag, credentials, `SIGSTORE_PATH`, and target proxy reachability.
+- Change image: keep `Dockerfile` aligned with commands used by scripts.
+- Change OpenShift job inputs: update `openshift/acceptance.yaml` parameters and README variable docs together.
+
+## Commands
+
+```bash
+./pr-check.sh
+docker run --rm -e HOST=... -e IMAGE=... -e TAG=... \
+  -e REGISTRY_USERNAME=... -e REGISTRY_PASSWORD=... \
+  -e SIGSTORE_PATH=... registry-proxy-test:pr-check
+```
+
+## Guardrails
+
+- Do not commit real credentials or private image names.
+- `REGISTRY_USERNAME` and `REGISTRY_PASSWORD` are live registry credentials; keep them in CI/job configuration, not source.
+- Quote shell variables unless word splitting is intentional.
+- Avoid sleeps; poll concrete service conditions.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,69 @@
+# registry-proxy-tests Architecture
+
+This repository is intentionally small. It packages shell-based acceptance checks into a container image so registry-proxy changes can be tested the same way in local development, OpenShift jobs, and Konflux pipelines.
+
+## Components
+
+```text
+Dockerfile                              Builds the test runner image
+execute.sh                              Entrypoint that runs all checks
+test-pull.sh                            Podman login and image pull validation
+test-sigstore.sh                        Sigstore redirect validation
+openshift/acceptance.yaml               OpenShift job definition
+.tekton/*pull-request.yaml              PR pipeline
+.tekton/*push.yaml                      Push pipeline
+build-deploy.sh                         Build/deploy helper
+pr-check.sh                             Local image build check
+```
+
+## Test Flow
+
+```mermaid
+sequenceDiagram
+    participant CI as CI or developer
+    participant Image as registry-proxy-tests container
+    participant Pull as test-pull.sh
+    participant Sig as test-sigstore.sh
+    participant Proxy as registry-proxy
+    participant Upstream as Upstream registry/content
+
+    CI->>Image: run container with HOST, IMAGE, TAG, credentials
+    Image->>Pull: execute image pull test
+    Pull->>Proxy: podman login
+    Pull->>Proxy: podman pull HOST/IMAGE:TAG
+    Proxy->>Upstream: fetch or proxy image content
+    Upstream-->>Proxy: manifest and blobs
+    Proxy-->>Pull: pull succeeds
+    Image->>Sig: execute sigstore redirect test
+    Sig->>Proxy: HEAD /containers/sigstore/SIGSTORE_PATH
+    Proxy-->>Sig: 301 Location: access.redhat.com sigstore URL
+    Image-->>CI: exit 0 only if both checks pass
+```
+
+## Inputs
+
+- `HOST`: registry-proxy host, for example `registry-proxy.example.com`.
+- `IMAGE`: repository path used for the pull test.
+- `TAG`: image tag used for the pull test.
+- `REGISTRY_USERNAME` and `REGISTRY_PASSWORD`: credentials for `podman login`.
+- `SIGSTORE_PATH`: path segment expected under `/containers/sigstore/`.
+
+OpenShift job defaults and parameter names are defined in `openshift/acceptance.yaml`. Keep the README, template parameters, and script variable names aligned.
+
+## Failure Modes
+
+- Missing Podman in the test image causes `test-pull.sh` to fail before login.
+- Invalid credentials fail during `podman login` or `podman pull`.
+- Incorrect `HOST`, `IMAGE`, or `TAG` fails image lookup.
+- Incorrect sigstore routing fails when the response lacks a 301 or has a different `Location` header.
+- Missing or malformed `SIGSTORE_PATH` makes the sigstore check build the wrong expected redirect URL.
+
+## Pipeline Role
+
+The tests are acceptance checks, not unit tests. They need a reachable registry-proxy deployment and test data that matches the environment. Keep assertions focused on externally observable behavior: login, pull, redirect status, and redirect target.
+
+## Integration Points
+
+- `registry-proxy`: target service under test.
+- `.tekton/registry-proxy-tests-*.yaml`: Konflux image build definitions.
+- `openshift/acceptance.yaml`: job template used to run the built image against a target registry-proxy deployment.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing to registry-proxy-tests
+
+This repository provides acceptance checks for registry-proxy deployments. Keep changes focused on observable proxy behavior: image pulls, authentication requirements, and sigstore redirects.
+
+## Running Locally
+
+```bash
+./pr-check.sh
+
+docker run --rm \
+  -e HOST=registry-proxy.example.com \
+  -e IMAGE=namespace/repository \
+  -e TAG=latest \
+  -e REGISTRY_USERNAME=user \
+  -e REGISTRY_PASSWORD=password \
+  -e SIGSTORE_PATH=namespace/repository@sha256:... \
+  registry-proxy-test:pr-check
+```
+
+## OpenShift
+
+```bash
+oc apply -f openshift/acceptance.yaml
+oc logs -f job/registry-proxy-tests
+```
+
+Adjust names and secrets to match the target namespace.
+
+The template parameters in `openshift/acceptance.yaml` map directly to the script environment variables. Keep those names in sync when adding inputs.
+
+## Adding Tests
+
+- Add a new script at the repository root or in a clearly named subdirectory.
+- Call the new script from `execute.sh`.
+- Document any new environment variable in `README.md` and `AGENTS.md`.
+- Make failure messages specific enough for CI logs.
+- Keep cleanup idempotent.
+
+## Pull Requests
+
+- State the registry-proxy environment tested.
+- Include the image build command and run command.
+- Do not commit real registry credentials, private image names, or generated logs.

--- a/README.md
+++ b/README.md
@@ -15,3 +15,26 @@ docker run -e HOST={HOST} \
 -e REGISTRY_PASSWORD={REGISTRY_PASSWORD} \
 registry-proxy-tests
 ```
+
+## Contextification Addendum
+
+```mermaid
+flowchart LR
+    image[registry-proxy-tests image]
+    entry[execute.sh]
+    pull[test-pull.sh]
+    sigstore[test-sigstore.sh]
+    proxy[registry-proxy target]
+
+    image --> entry
+    entry --> pull
+    entry --> sigstore
+    pull --> proxy
+    sigstore --> proxy
+```
+
+Required variables: `HOST`, `IMAGE`, `TAG`, `REGISTRY_USERNAME`, `REGISTRY_PASSWORD`, and `SIGSTORE_PATH`.
+
+Use `./pr-check.sh` to build the local test image as `registry-proxy-test:pr-check`. Add new checks as scripts called by `execute.sh`. OpenShift job parameters live in `openshift/acceptance.yaml`.
+
+Related repo: [registry-proxy](https://github.com/quay/registry-proxy).


### PR DESCRIPTION
## Summary
Adds required contextification docs for `registry-proxy-tests` as part of PROJQUAY-11621.

## Changes
  - Adds `AGENTS.md` with low-token routing for entrypoint, test scripts, OpenShift job, and Konflux files.
  - Adds `ARCHITECTURE.md` describing the acceptance test image, test flow, required inputs, failure modes, and
  integration points.
  - Adds `CONTRIBUTING.md` with local run, OpenShift job, test addition, and PR guidance.
  - Updates `README.md` with a contextification addendum, diagram, required variables, local image build command, and
  related repo link.